### PR TITLE
fly.ioへのリリース確認

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,28 @@
+name: CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'fly.io deploy'
+        required: false
+        default: 'main'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      FLY_APP: tax-assist
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Deploy to Fly
+        run: |
+          flyctl deploy --app "$FLY_APP" --remote-only

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY . .
 
 EXPOSE 3000
 
-CMD [ "bash", "-lc", "bin/rails db:prepare && bin/rails s -b 0.0.0.0" ]
+CMD ["bash","-lc","bin/rails db:prepare && bin/rails s -b 0.0.0.0 -p ${PORT:-3000}"]

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development do
   gem "web-console"
 
   # Highlight the fine-grained location where an error occurred [https://github.com/ruby/error_highlight]
- # gem "error_highlight", ">= 0.4.0", platforms: [ :ruby ]
+  # gem "error_highlight", ">= 0.4.0", platforms: [ :ruby ]
 end
 
 group :test do

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   web:
     build:
       context: .
-      dockerfile: dockerfile
+      dockerfile: Dockerfile
     volumes:
       - .:/workspace:cached
     ports:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << "tax-assist.fly.dev"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root to: proc { [200, {"Content-Type"=>"text/plain"}, ["Hello from tax-assist"]] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root to: proc { [200, {"Content-Type"=>"text/plain"}, ["Hello from tax-assist"]] }
+  root to: proc { [ 200, { "Content-Type" => "text/plain" }, [ "Hello from tax-assist" ] ] }
 end

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,12 @@
+app = "tax-assist"
+primary_region = "nrt"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+[deploy]
+  release_command = "bin/rails db:migrate"


### PR DESCRIPTION
## 概要
fly.ioへのリリース確認


## 対応内容
 - 前項にて作成したコンテナを外部公開し、接続確認する。
 
 ## 動作確認
 ```
 $ flyctl apps open
opening https://tax-assist.fly.dev/ ...
 
 $ curl https://tax-assist.fly.dev/ -i
HTTP/2 200
content-type: text/plain
etag: W/"f645e90850234f81f03a9a5c7efa5196"
cache-control: max-age=0, private, must-revalidate
x-request-id: 787f4598-7cdc-43c7-9b9c-8a8645831a7e
x-runtime: 0.001039
strict-transport-security: max-age=63072000; includeSubDomains
content-length: 21
date: Sun, 21 Sep 2025 07:30:31 GMT
server: Fly/0768d016b (2025-09-18)
via: 2 fly.io, 2 fly.io
fly-request-id: 01K5NJWY9XPK67589VC7MBAZS8-syd
 ```
 
 ## 関連
 close #12 
 