### PR TITLE
メニュー画面と関連ページの作成対応

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   ],
   "service": "web",
   "workspaceFolder": "/workspace",
-  "overrideCommand": true,
+  "overrideCommand": false,
   "remoteEnv": {
     "BUNDLE_PATH": "/usr/local/bundle"
   },

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "puma", ">= 5.0"
 gem "jbuilder"
 gem "importmap-rails"
 gem "devise", "~> 4.9"
+gem "rake", "~> 13.3"
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.2)
+  rake (~> 13.3)
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -147,3 +147,152 @@ body.auth-layout {
     justify-content: center;
     align-items: center;
 }
+
+/* --- spacing: flashが固定表示で隠れないように上に余白 --- */
+body {
+    padding-top: 56px;
+}
+
+@media (max-width: 480px) {
+    body {
+        padding-top: 64px;
+    }
+}
+
+/* --- フォーム（メニューの年度選択） --- */
+.form-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 12px 0;
+}
+
+.form-row label {
+    min-width: 90px;
+    color: #333;
+}
+
+select,
+button,
+input[type="submit"] {
+    font-size: 16px;
+    line-height: 1.2;
+    height: 36px;
+}
+
+select {
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    background: #fff;
+}
+
+/* --- ボタン拡張 --- */
+.btn {
+    transition: filter .15s ease;
+}
+
+.btn:hover,
+.btn:focus {
+    filter: brightness(0.95);
+}
+
+.btn-block {
+    width: 100%;
+    display: inline-block;
+}
+
+.btn-outline {
+    background: #fff;
+    color: #111;
+    border: 1px solid #111;
+}
+
+.btn-outline:hover {
+    background: #111;
+    color: #fff;
+}
+
+/* --- ページ見出しとコンテナ --- */
+.page-title {
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: .02em;
+    margin: 8px 0 16px;
+}
+
+.page small {
+    font-size: 14px;
+    color: #666;
+    margin-left: 8px;
+}
+
+/* --- 会計メニューのリスト --- */
+.menu-list {
+    list-style: none;
+    padding: 0;
+    margin: 16px 0;
+    display: grid;
+    gap: 12px;
+    max-width: 320px;
+}
+
+.menu-list a.btn {
+    display: block;
+}
+
+.menu-actions {
+    margin-top: 12px;
+}
+
+/* --- タイルの余白微調整（既存 .tiles/.tile を活かす） --- */
+.tiles {
+    gap: 20px;
+}
+
+.tile {
+    padding: 18px;
+}
+
+.page .btn {
+    width: auto;
+    display: inline-block;
+    padding: 8px 16px;
+}
+
+.page-center {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.auth.wide {
+    width: min(520px, 92vw);
+    text-align: center;
+}
+
+.hstack {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.center-actions .btn {
+    width: auto;
+    display: inline-block;
+}
+
+.vstack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: stretch;
+}
+
+.btn-sm {
+    padding: 6px 10px;
+    font-size: 14px;
+}

--- a/app/controllers/accounting_menu_controller.rb
+++ b/app/controllers/accounting_menu_controller.rb
@@ -1,0 +1,11 @@
+class AccountingMenuController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @period = current_user.accounting_periods.find_by(id: session[:accounting_period_id])
+    unless @period
+      redirect_to authenticated_root_path, alert: "会計年度を選択してください"
+      nil
+    end
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,50 @@
+class AccountsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_account, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @accounts = current_user.accounts.order(:category, :name)
+  end
+
+  def show
+    redirect_to edit_account_path(@account)
+  end
+
+  def new
+    @account = current_user.accounts.new
+  end
+
+  def create
+    @account = current_user.accounts.new(account_params)
+    if @account.save
+      redirect_to accounts_path, notice: "勘定科目を作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @account.update(account_params)
+      redirect_to accounts_path, notice: "勘定科目を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @account.destroy
+    redirect_to accounts_path, notice: "勘定科目を削除しました"
+  end
+
+  private
+
+  def set_account
+    @account = current_user.accounts.find(params[:id])
+  end
+
+  def account_params
+    params.require(:account).permit(:name, :category)
+  end
+end

--- a/app/controllers/business_controller.rb
+++ b/app/controllers/business_controller.rb
@@ -1,0 +1,22 @@
+class BusinessController < ApplicationController
+  before_action :authenticate_user!
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    if @user.update(business_params)
+      redirect_to edit_business_path, notice: "事業者情報を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def business_params
+    params.require(:user).permit(:business_name)
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,20 @@
 class HomeController < ApplicationController
   before_action :authenticate_user!
-  def index; end
+
+  def index
+    y = Date.current.year
+    periods = current_user.accounting_periods.where("accounting_year BETWEEN ? AND ?", 2024, y)
+    @accounting_periods = periods.sort_by { |p| [ p.accounting_year == y ? 0 : 1, -p.accounting_year ] }
+    @selected_period_id = session[:accounting_period_id] || periods.find_by(accounting_year: y)&.id
+  end
+
+  def select_accounting_period
+    period = current_user.accounting_periods.find_by(id: params[:accounting_period_id])
+    unless period
+      redirect_to authenticated_root_path, alert: "会計年度を選択してください"
+      return
+    end
+    session[:accounting_period_id] = period.id
+    redirect_to accounting_menu_path
+  end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,5 @@
+class Account < ApplicationRecord
+  belongs_to :user
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+  validates :category, presence: true
+end

--- a/app/models/accounting_period.rb
+++ b/app/models/accounting_period.rb
@@ -1,0 +1,4 @@
+class AccountingPeriod < ApplicationRecord
+  belongs_to :user
+  validates :accounting_year, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,13 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :email, presence: true, lowercase: true, uniqueness: true
+  has_many :accounting_periods, dependent: :destroy
+  has_many :accounts, dependent: :destroy
+
+  after_create :setup_default_periods
+  def setup_default_periods
+    (2024..Date.current.year).each do |y|
+      accounting_periods.find_or_create_by!(accounting_year: y)
+    end
+  end
 end

--- a/app/views/accounting_menu/show.html.erb
+++ b/app/views/accounting_menu/show.html.erb
@@ -1,0 +1,9 @@
+<div class="page">
+    <h1>会計メニュー <small>選択中の会計年度: <%= @period.accounting_year %></small></h1>
+    <ul class="menu-list">
+        <li><%= link_to "開始残高", "#", class: "btn" %></li>
+        <li><%= link_to "仕訳登録", "#", class: "btn" %></li>
+        <li><%= link_to "仕訳の一覧", "#", class: "btn" %></li>
+        <li><%= link_to "戻る", authenticated_root_path %></li>
+    </ul>
+</div>

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -1,0 +1,17 @@
+<%= render "shared/error_messages", object: @account %>
+<%= form_with model: @account, local: true, html: { class: "form" } do |f| %>
+<div class="field">
+    <label for="account_name">科目名</label>
+    <%= f.text_field :name %>
+</div>
+<div class="field">
+    <label for="account_category">区分</label>
+    <%= f.select :category,
+      I18n.t("accounts.categories").map { |k, v| [v, k] },
+      include_blank: "選択してください" %>
+</div>
+<div class="actions vstack">
+    <%= f.submit "保存", class: "btn btn-sm btn-block" %>
+    <%= link_to "戻る", accounts_path, class: "btn btn-outline btn-sm btn-block" %>
+</div>
+<% end %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -1,0 +1,6 @@
+<div class="page-center">
+    <div class="auth wide">
+        <h1 class="page-title">勘定科目の編集</h1>
+        <%= render "form" %>
+    </div>
+</div>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,0 +1,40 @@
+<div class="page">
+    <h1 class="page-title">勘定科目マスタ</h1>
+
+    <div class="actions" style="margin-bottom:12px;">
+        <%= link_to "新規追加", new_account_path, class: "btn btn-sm" %>
+        <%= link_to "戻る", authenticated_root_path, class: "btn btn-outline btn-sm" %>
+    </div>
+
+    <table style="width:100%; border-collapse:collapse; background:#fff; border:1px solid #ddd; border-radius:12px; overflow:hidden;">
+        <thead>
+            <tr style="background:#f7f7f7;">
+                <th style="text-align:left; padding:10px;">科目名</th>
+                <th style="text-align:left; padding:10px;">区分</th>
+                <th style="width:180px;"></th>
+            </tr>
+        </thead>
+        <tbody>
+            <% if @accounts.any? %>
+            <% @accounts.each do |a| %>
+            <tr>
+                <td style="padding:10px;"><%= a.name %></td>
+                <td style="padding:10px;"><%= I18n.t("accounts.categories.#{a.category}", default: a.category) %></td>
+                <td style="padding:10px; text-align:right;">
+                    <%= link_to "編集", edit_account_path(a), class: "btn btn-sm" %>
+                   <%= button_to "削除",
+                        account_path(a),
+                        method: :delete,
+                        form: { onsubmit: "return confirm('#{j a.name} を削除しますか？');" },
+                        class: "btn btn-outline btn-sm" %>
+                </td>
+            </tr>
+            <% end %>
+            <% else %>
+            <tr>
+                <td colspan="3" style="padding:16px; text-align:center; color:#666;">登録された勘定科目はありません</td>
+            </tr>
+            <% end %>
+        </tbody>
+    </table>
+</div>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,0 +1,6 @@
+<div class="page-center">
+    <div class="auth wide">
+        <h1 class="page-title">勘定科目の新規作成</h1>
+        <%= render "form" %>
+    </div>
+</div>

--- a/app/views/business/edit.html.erb
+++ b/app/views/business/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="page-center">
+  <div class="auth wide">
+    <h1 class="page-title">事業者情報</h1>
+
+    <%= form_with model: @user, url: business_path, method: :patch, local: true, html: { class: "form" } do |f| %>
+      <div class="field">
+        <label for="user_business_name">屋号（事業者名）</label>
+        <%= f.text_field :business_name, placeholder: "例）山田商店" %>
+      </div>
+    <div class="actions vstack">
+      <%= f.submit "更新", class: "btn btn-sm btn-block" %>
+      <%= link_to "戻る", authenticated_root_path, class: "btn btn-outline btn-sm btn-block" %>
+    </div>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,23 @@
-<div class="page">
-  <h2>メニュー</h2>
-  <div class="auth">
-    <%= link_to "メール/パスワード変更", edit_account_path, class: "btn" %>
-    <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn" %>
-  </div>
+<div class="page-center">
+    <div class="auth wide">
+        <h1 class="page-title">メニュー</h1>
+
+        <%= form_with url: select_accounting_period_path, method: :post, local: true do %>
+        <div class="hstack" style="margin: 8px 0 16px;">
+            <label for="accounting_period_id">会計年度</label>
+            <%= select_tag :accounting_period_id,
+          options_from_collection_for_select(@accounting_periods, :id, :accounting_year, @selected_period_id || session[:accounting_period_id]),
+          include_blank: "選択してください" %>
+            <%= submit_tag "次へ", class: "btn" %>
+        </div>
+        <% end %>
+
+        <div class="center-actions vstack">
+            <%= link_to "勘定科目マスタ", accounts_path, class: "btn btn-sm btn-block" %>
+            <%= link_to "事業者情報", edit_business_path, class: "btn btn-sm btn-block" %>
+            <%= link_to "メール/パスワード変更", edit_user_account_path, class: "btn btn-sm btn-block" %>
+            <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-sm btn-block", form: { class: "inline" } %>
+        </div>
+
+    </div>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="flash alert" style="display:block;">
+    <ul style="margin:0; padding-left:18px; text-align:left;">
+      <% object.errors.full_messages.each do |m| %>
+        <li><%= m %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,9 @@ module TaxAssist
     config.autoload_lib(ignore: %w[assets tasks])
     config.autoload_paths << Rails.root.join("app/validators")
     config.eager_load_paths << Rails.root.join("app/validators")
+    config.i18n.default_locale = :ja
+    config.i18n.available_locales = [ :ja, :en ]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,38 @@
+ja:
+  accounts:
+    categories:
+      asset: 資産
+      liability: 負債
+      equity: 純資産
+      revenue: 収益
+      expense: 費用
+
+  devise:
+    failure:
+      not_found_in_database: メールアドレスまたはパスワードが正しくありません
+      invalid: メールアドレスまたはパスワードが正しくありません
+    sessions:
+      signed_in: ログインしました
+      signed_out: ログアウトしました
+    registrations:
+      signed_up: 登録が完了しました
+  activerecord:
+    attributes:
+      account:
+        name: 科目名
+        category: 区分
+      user:
+        business_name: 屋号（事業者名）
+    errors:
+      models:
+        account:
+          attributes:
+            name:
+              blank: を入力してください
+            category:
+              blank: を入力してください
+              inclusion: は正しい値を選択してください
+  errors:
+    messages:
+      blank: を入力してください
+      inclusion: は一覧に含まれていません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resource :account, only: [ :edit ], controller: :account do
+  resource :user_account, only: [ :edit ], controller: :account, path: "account" do
     patch :email
     patch :password
   end
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+
+  post "select_accounting_period", to: "home#select_accounting_period", as: :select_accounting_period
+  resource :accounting_menu, only: :show, controller: :accounting_menu
+  resource :business, only: [ :edit, :update ], controller: :business
+  resources :accounts
 
   authenticated :user do
     root "home#index", as: :authenticated_root

--- a/db/migrate/20250930125242_create_accounting_periods.rb
+++ b/db/migrate/20250930125242_create_accounting_periods.rb
@@ -1,0 +1,12 @@
+class CreateAccountingPeriods < ActiveRecord::Migration[7.2]
+  def change
+    create_table :accounting_periods do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :accounting_year
+      t.datetime :locked_at
+
+      t.timestamps
+    end
+    add_index :accounting_periods, [ :user_id, :accounting_year ], unique: true
+  end
+end

--- a/db/migrate/20251001131106_create_accounts.rb
+++ b/db/migrate/20251001131106_create_accounts.rb
@@ -1,0 +1,12 @@
+class CreateAccounts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :accounts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+      t.string :category
+
+      t.timestamps
+    end
+    add_index :accounts, [ :user_id, :name ], unique: true
+  end
+end

--- a/db/migrate/20251004150429_add_business_name_to_users.rb
+++ b/db/migrate/20251004150429_add_business_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddBusinessNameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :business_name, :string
+  end
+end

--- a/db/migrate/20251004153112_enforce_not_null_on_accounts.rb
+++ b/db/migrate/20251004153112_enforce_not_null_on_accounts.rb
@@ -1,0 +1,11 @@
+class EnforceNotNullOnAccounts < ActiveRecord::Migration[7.2]
+  def up
+    change_column_null :accounts, :name, false
+    change_column_null :accounts, :category, false
+  end
+
+  def down
+    change_column_null :accounts, :name, true
+    change_column_null :accounts, :category, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_27_102851) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_04_153112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "accounting_periods", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "accounting_year"
+    t.datetime "locked_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "accounting_year"], name: "index_accounting_periods_on_user_id_and_accounting_year", unique: true
+    t.index ["user_id"], name: "index_accounting_periods_on_user_id"
+  end
+
+  create_table "accounts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_accounts_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_accounts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -22,7 +42,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_27_102851) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "business_name"
     t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "accounting_periods", "users"
+  add_foreign_key "accounts", "users"
 end

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  name: MyString
+  category: MyString
+
+two:
+  user: two
+  name: MyString
+  category: MyString

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AccountTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
メニュー画面と関連ページの作成


## 対応内容
 - 年度設定からの会計メニュー画面への遷移とそのページ作成
 - 勘定科目マスタのページ作成
 - 事業者登録情報ページの作成
 
 ## 動作確認
   各ページ遷移と作成とその値の変更を確認済み
   
   #8  