### PR TITLE
仕訳の実装を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,11 @@
   ],
   "service": "web",
   "workspaceFolder": "/workspace",
-  "overrideCommand": false,
+  "overrideCommand": true,
+  "runServices": [
+    "db",
+    "web"
+  ],
   "remoteEnv": {
     "BUNDLE_PATH": "/usr/local/bundle"
   },

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -342,3 +342,22 @@ select {
     align-items: center;
     justify-content: center
 }
+
+.actions-col {
+    width: 180px;
+}
+
+.actions-cell {
+    text-align: right;
+}
+
+.action-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.action-buttons .btn {
+    width: auto;
+    padding: 6px 10px;
+}

--- a/app/controllers/journal_entries_controller.rb
+++ b/app/controllers/journal_entries_controller.rb
@@ -1,0 +1,59 @@
+class JournalEntriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_accounting_period!
+  before_action :set_entry, only: [ :edit, :update ]
+
+  def index
+    @entries = JournalEntry.where(accounting_period_id: current_period.id).recent
+    @entry = JournalEntry.new(
+      accounting_period_id: current_period.id,
+      entry_date: Date.current
+    )
+    @entry.journal_entry_lines.build if @entry.journal_entry_lines.empty?
+  end
+
+  def create
+    @entry = JournalEntry.new(entry_params.merge(accounting_period_id: current_period.id))
+    if @entry.save
+      redirect_to journal_entries_path, notice: "仕訳を登録しました"
+    else
+      @entries = JournalEntry.where(accounting_period_id: current_period.id).recent
+      flash.now[:alert] = @entry.errors.full_messages.join(" / ")
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @entry.update(entry_params)
+      redirect_to journal_entries_path, notice: "仕訳を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @entry = JournalEntry.where(accounting_period_id: current_period.id).find(params[:id])
+    @entry.destroy
+    redirect_to journal_entries_path, notice: "仕訳を削除しました"
+  end
+
+  private
+
+  def set_entry
+    @entry = JournalEntry.where(accounting_period_id: current_period.id).find(params[:id])
+  end
+
+  def entry_params
+    params.require(:journal_entry).permit(
+      :entry_date,
+      journal_entry_lines_attributes: [ :id, :account_id, :dc, :amount, :memo, :_destroy ]
+    )
+  end
+
+  def next_entry_no
+    last_no = JournalEntry.where(accounting_period_id: current_period.id).maximum(:entry_no)
+    (last_no || 0) + 1
+  end
+end

--- a/app/models/journal_entry.rb
+++ b/app/models/journal_entry.rb
@@ -1,0 +1,20 @@
+class JournalEntry < ApplicationRecord
+  belongs_to :accounting_period
+  has_many :journal_entry_lines, inverse_of: :journal_entry, dependent: :destroy
+  accepts_nested_attributes_for :journal_entry_lines, allow_destroy: true
+
+  before_validation :assign_entry_no, on: :create
+
+  validates :entry_no, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :entry_date, presence: true
+
+  scope :recent, -> { order(entry_date: :desc, entry_no: :desc) }
+
+  private
+
+  def assign_entry_no
+    return if entry_no.present?
+    last = self.class.where(accounting_period_id: accounting_period_id).maximum(:entry_no)
+    self.entry_no = (last || 0) + 1
+  end
+end

--- a/app/models/journal_entry_line.rb
+++ b/app/models/journal_entry_line.rb
@@ -1,0 +1,7 @@
+class JournalEntryLine < ApplicationRecord
+  belongs_to :journal_entry, inverse_of: :journal_entry_lines
+  belongs_to :account
+  validates :account_id, presence: true
+  validates :dc, inclusion: { in: %w[debit credit] }
+  validates :amount, numericality: { only_integer: true, greater_than: 0 }
+end

--- a/app/views/accounting_menu/show.html.erb
+++ b/app/views/accounting_menu/show.html.erb
@@ -8,8 +8,8 @@
 
         <ul class="menu-list">
             <li><%= link_to "開始残高", opening_balances_path, class: "btn" %></li>
-            <li><%= link_to "仕訳登録", "#", class: "btn" %></li>
-            <li><%= link_to "仕訳の一覧", "#", class: "btn" %></li>
+            <li><%= link_to "仕訳 新規登録/編集", journal_entries_path, class: "btn" %></li>
+
             <li><%= link_to "戻る", authenticated_root_path, class: "btn btn-outline" %></li>
         </ul>
     </div>

--- a/app/views/journal_entries/_lines_fields.html.erb
+++ b/app/views/journal_entries/_lines_fields.html.erb
@@ -1,0 +1,71 @@
+<div class="table-wrap" style="margin-top:12px;">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>勘定科目</th>
+                <th>貸借</th>
+                <th style="text-align:right;">金額</th>
+                <th>メモ</th>
+                <th style="width:100px;"></th>
+            </tr>
+        </thead>
+        <tbody id="lines">
+            <%= f.fields_for :journal_entry_lines do |lf| %>
+            <tr class="line">
+                <%= lf.hidden_field :id %>
+                <%= lf.hidden_field :_destroy, value: 0 %>
+                <td><%= lf.collection_select :account_id, current_user.accounts.order(:category, :name), :id, :name, include_blank: "選択" %></td>
+                <td><%= lf.select :dc, [["借方","debit"],["貸方","credit"]], include_blank: "選択" %></td>
+                <td style="text-align:right;"><%= lf.number_field :amount, min: 0, step: 1 %></td>
+                <td><%= lf.text_field :memo %></td>
+                <td>
+                    <button type="button" class="btn btn-outline btn-sm" onclick="this.closest('tr').querySelector('input[name*=\'[_destroy]\']').value=1; this.closest('tr').style.display='none';">
+                        行削除
+                    </button>
+                </td>
+            </tr>
+            <% end %>
+        </tbody>
+    </table>
+
+    <div class="actions" style="margin-top:8px;">
+        <button type="button" class="btn btn-sm" id="add-line-btn">行を追加</button>
+    </div>
+</div>
+
+<%# 新規行のプロトタイプ（Railsの child_index 置換） %>
+<% prototype_html = capture do %>
+<%= f.fields_for :journal_entry_lines, JournalEntryLine.new, child_index: "NEW_RECORD" do |lf| %>
+<tr class="line">
+    <%= lf.hidden_field :id %>
+    <%= lf.hidden_field :_destroy, value: 0 %>
+    <td><%= lf.collection_select :account_id, current_user.accounts.order(:category, :name), :id, :name, include_blank: "選択" %></td>
+    <td><%= lf.select :dc, [["借方","debit"],["貸方","credit"]], include_blank: "選択" %></td>
+    <td style="text-align:right;"><%= lf.number_field :amount, min: 0, step: 1, value: 0 %></td>
+    <td><%= lf.text_field :memo %></td>
+    <td>
+        <button type="button" class="btn btn-outline btn-sm" onclick="this.closest('tr').querySelector('input[name*=\'[_destroy]\']').value=1; this.closest('tr').style.display='none';">
+            行削除
+        </button>
+    </td>
+</tr>
+<% end %>
+<% end %>
+
+<script>
+    (function() {
+        var addBtn = document.getElementById('add-line-btn');
+        if (!addBtn) return;
+        var tbody = document.getElementById('lines');
+        var template = `<%= j prototype_html %>`; // NEW_RECORD を都度置換
+
+        addBtn.addEventListener('click', function() {
+            var unique = Date.now().toString();
+            var html = template.replace(/NEW_RECORD/g, unique);
+            var temp = document.createElement('tbody');
+            temp.innerHTML = html.trim();
+            var row = temp.firstElementChild;
+            tbody.appendChild(row);
+        });
+    })();
+</script>

--- a/app/views/journal_entries/edit.html.erb
+++ b/app/views/journal_entries/edit.html.erb
@@ -1,0 +1,25 @@
+<div class="page">
+  <div class="narrow">
+    <h1 class="page-title">仕訳 編集</h1>
+
+    <%= form_with model: @entry, local: true, html: { class: "form" } do |f| %>
+      <div class="field">
+        <label>伝票No</label>
+        <div><%= @entry.entry_no %></div>
+      </div>
+
+      <div class="field">
+        <label for="journal_entry_entry_date">日付</label>
+        <%= f.date_field :entry_date %>
+      </div>
+
+      <% @entry.journal_entry_lines.build if @entry.journal_entry_lines.empty? %>
+      <%= render partial: "lines_fields", locals: { f: f } %>
+
+      <div class="actions vstack">
+        <%= f.submit "更新", class: "btn btn-sm btn-block" %>
+        <%= link_to "戻る", journal_entries_path, class: "btn btn-outline btn-sm btn-block" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/journal_entries/index.html.erb
+++ b/app/views/journal_entries/index.html.erb
@@ -1,0 +1,62 @@
+<div class="page">
+  <div class="narrow">
+    <h1 class="page-title">仕訳 新規登録/編集</h1>
+    <div class="year-banner">選択中の会計年度:<span class="year-pill"><%= current_period.accounting_year %></span></div>
+
+    <div class="menu-group" style="margin-top:16px;">
+      <h2 class="group-title">新規登録</h2>
+      <%= form_with model: @entry, url: journal_entries_path, method: :post, local: true, html: { class: "form" } do |f| %>
+        <div class="field">
+          <label for="journal_entry_entry_date">日付</label>
+          <%= f.date_field :entry_date %>
+        </div>
+
+        <%= render partial: "lines_fields", locals: { f: f } %>
+
+        <div class="actions vstack">
+          <%= f.submit "保存", class: "btn btn-sm btn-block" %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="table-wrap" style="margin-top:16px;">
+    <table class="table">
+        <thead>
+        <tr>
+            <th>伝票No</th>
+            <th>日付</th>
+            <th class="actions-col">操作</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% if @entries.any? %>
+            <% @entries.each do |e| %>
+            <tr>
+                <td><%= e.entry_no %></td>
+                <td><%= e.entry_date %></td>
+                <td class="actions-cell">
+                <div class="action-buttons">
+                    <%= link_to "編集", edit_journal_entry_path(e), class: "btn btn-sm" %>
+                    <%= button_to "削除", journal_entry_path(e),
+                        method: :delete,
+                        form: { data: { turbo_confirm: "削除しますか？" } },
+                        class: "btn btn-outline btn-sm" %>
+                </div>
+                </td>
+            </tr>
+            <% end %>
+        <% else %>
+            <tr>
+            <td colspan="3" style="text-align:center;color:#666;">登録された仕訳はありません</td>
+            </tr>
+        <% end %>
+        </tbody>
+    </table>
+    </div>
+
+
+    <div class="actions" style="margin-top:12px;">
+      <%= link_to "会計メニューに戻る", accounting_menu_path, class: "btn btn-outline btn-sm btn-block" %>
+    </div>
+  </div>
+</div>

--- a/app/views/journal_entries/new.html.erb
+++ b/app/views/journal_entries/new.html.erb
@@ -1,0 +1,21 @@
+<div class="page">
+    <div class="narrow">
+        <h1 class="page-title">仕訳 新規</h1>
+        <%= form_with model: @entry, local: true, html: { class: "form" } do |f| %>
+        <div class="field">
+            <label for="journal_entry_entry_no">伝票No</label>
+            <%= f.number_field :entry_no, min: 1 %>
+        </div>
+        <div class="field">
+            <label for="journal_entry_entry_date">日付</label>
+            <%= f.date_field :entry_date %>
+        </div>
+        <% @entry.journal_entry_lines.build if @entry.journal_entry_lines.empty? %>
+        <%= render partial: "lines_fields", locals: { f: f } %>
+        <div class="actions vstack">
+            <%= f.submit "保存", class: "btn btn-sm btn-block" %>
+            <%= link_to "戻る", journal_entries_path, class: "btn btn-outline btn-sm btn-block" %>
+        </div>
+        <% end %>
+    </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   resource :business, only: [ :edit, :update ], controller: :business
   resources :accounts
   resource :opening_balances, only: [ :show, :update ], controller: :opening_balances
+  resources :journal_entries, only: [ :index, :create, :edit, :update, :destroy ]
 
   authenticated :user do
     root "home#index", as: :authenticated_root

--- a/db/migrate/20251005084115_create_journal_entries.rb
+++ b/db/migrate/20251005084115_create_journal_entries.rb
@@ -1,0 +1,12 @@
+class CreateJournalEntries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journal_entries do |t|
+      t.references :accounting_period, null: false, foreign_key: true
+      t.integer :entry_no,    null: false
+      t.date    :entry_date,  null: false
+      t.string  :description, null: false, default: ""
+      t.timestamps
+    end
+    add_index :journal_entries, [ :accounting_period_id, :entry_no ], unique: true
+  end
+end

--- a/db/migrate/20251005084137_create_journal_entry_lines.rb
+++ b/db/migrate/20251005084137_create_journal_entry_lines.rb
@@ -1,0 +1,13 @@
+class CreateJournalEntryLines < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journal_entry_lines do |t|
+      t.references :journal_entry, null: false, foreign_key: true
+      t.references :account,       null: false, foreign_key: true
+      t.string  :dc,     null: false
+      t.integer :amount, null: false, default: 0
+      t.string  :memo
+      t.timestamps
+    end
+    add_index :journal_entry_lines, [ :journal_entry_id, :account_id ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_05_031501) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_05_084137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,30 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_05_031501) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "name"], name: "index_accounts_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
+  end
+
+  create_table "journal_entries", force: :cascade do |t|
+    t.bigint "accounting_period_id", null: false
+    t.integer "entry_no", null: false
+    t.date "entry_date", null: false
+    t.string "description", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["accounting_period_id", "entry_no"], name: "index_journal_entries_on_accounting_period_id_and_entry_no", unique: true
+    t.index ["accounting_period_id"], name: "index_journal_entries_on_accounting_period_id"
+  end
+
+  create_table "journal_entry_lines", force: :cascade do |t|
+    t.bigint "journal_entry_id", null: false
+    t.bigint "account_id", null: false
+    t.string "dc", null: false
+    t.integer "amount", default: 0, null: false
+    t.string "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_journal_entry_lines_on_account_id"
+    t.index ["journal_entry_id", "account_id"], name: "index_journal_entry_lines_on_journal_entry_id_and_account_id"
+    t.index ["journal_entry_id"], name: "index_journal_entry_lines_on_journal_entry_id"
   end
 
   create_table "opening_balances", force: :cascade do |t|
@@ -61,6 +85,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_05_031501) do
 
   add_foreign_key "accounting_periods", "users"
   add_foreign_key "accounts", "users"
+  add_foreign_key "journal_entries", "accounting_periods"
+  add_foreign_key "journal_entry_lines", "accounts"
+  add_foreign_key "journal_entry_lines", "journal_entries"
   add_foreign_key "opening_balances", "accounting_periods"
   add_foreign_key "opening_balances", "accounts"
 end

--- a/test/fixtures/journal_entries.yml
+++ b/test/fixtures/journal_entries.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  accounting_period: one
+  entry_no: 1
+  entry_date: 2025-10-05
+  description: MyString
+
+two:
+  accounting_period: two
+  entry_no: 1
+  entry_date: 2025-10-05
+  description: MyString

--- a/test/fixtures/journal_entry_lines.yml
+++ b/test/fixtures/journal_entry_lines.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  journal_entry: one
+  account: one
+  dc: MyString
+  amount: 1
+  memo: MyString
+
+two:
+  journal_entry: two
+  account: two
+  dc: MyString
+  amount: 1
+  memo: MyString

--- a/test/models/journal_entry_line_test.rb
+++ b/test/models/journal_entry_line_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class JournalEntryLineTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/journal_entry_test.rb
+++ b/test/models/journal_entry_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class JournalEntryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
仕訳用の実装

## 対応内容
仕訳の登録・変更・削除をできるようページを作成する。

## 動作確認
仕訳の登録画面への遷移と新規登録・変更・削除を確認済み

fix #9 